### PR TITLE
[Feat] 리뷰 분석 페이지 FE, BE 연동

### DIFF
--- a/src/api/reviews.ts
+++ b/src/api/reviews.ts
@@ -1,0 +1,51 @@
+import { API_BASE_URL } from "../config/api";
+
+export interface CustomersSay {
+  review_count: number;
+  current_text: string;
+  highlight: string;
+  updated_at: string;
+}
+
+export interface Reputation {
+  score: number;
+  rating: number;
+  review_count: number;
+}
+
+export interface Sentiment {
+  positive_pct: number;
+  negative_pct: number;
+}
+
+export interface RatingDistItem {
+  star: number;
+  pct: number;
+}
+
+export interface KeywordInsight {
+  aspect_name: string;
+  mention_total: number;
+  score: number;
+  summary: string;
+  mention_positive: number;
+  mention_negative: number;
+}
+
+export interface ReviewAnalysisResponse {
+  product_id: number;
+  snapshot_time: string;
+  customers_say: CustomersSay;
+  reputation: Reputation;
+  sentiment: Sentiment;
+  rating_distribution: RatingDistItem[];
+  keyword_insights: KeywordInsight[];
+}
+
+export async function fetchProductReviewAnalysis(productId: number): Promise<ReviewAnalysisResponse> {
+  const res = await fetch(`${API_BASE_URL}/api/laneige/products/${productId}/review-analysis`);
+  if (!res.ok) {
+    throw new Error("Failed to fetch review analysis");
+  }
+  return res.json() as Promise<ReviewAnalysisResponse>;
+}

--- a/src/styles/ReviewAnalysis.css
+++ b/src/styles/ReviewAnalysis.css
@@ -201,7 +201,7 @@
 }
 
 .customer-feedback__quote {
-  font-size: 16px;
+  font-size: 15px;
   font-weight: 400;
   color: #383838;
   line-height: 1.6;
@@ -209,7 +209,7 @@
   font-style: normal;
   background-color: #f6f6f6;
   border-radius: 50px;
-  padding: 15px 30px;
+  padding: 30px 30px;
 }
 
 /* ========== 감정 분석 섹션 ========== */


### PR DESCRIPTION
### 📑 #27 리뷰 분석 페이지
- close #27 

<br>

### ✨️ 작업 내용
- 전체 FE 디자인 변경
- 라네즈 제품 리스트 조회 API 연동
- 각 제품에 대한 리뷰 데이터 조회 API 연동

<br>

### 📷 스크린샷
<img width="1439" height="922" alt="스크린샷 2026-01-31 22 24 25" src="https://github.com/user-attachments/assets/468c80b5-936d-4063-80d3-b27aa1c75707" />
<img width="1439" height="922" alt="스크린샷 2026-01-31 22 24 34" src="https://github.com/user-attachments/assets/d97ea2a9-6922-430a-8459-244abc1b382c" />
<img width="1439" height="922" alt="스크린샷 2026-01-31 22 24 41" src="https://github.com/user-attachments/assets/49a5d243-c3be-4bec-a11e-7d6bdc5069e2" />



### 💭 코멘트
- 신뢰도 점수: 지금 긍정 리뷰 퍼센트 점수 그대로 보여주고 있는데 나중에 점수 산출 방식 어떻게 할지 정하기
- 영어 데이터로 받고 있는데, 나중에 한국어로 보여주는 것도 괜찮아 보임
