### PR TITLE
[Feat] LLM 전달 데이터 연결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ export interface InsightItem {
   page: PageType;
   timestamp: Date;
   uniqueKey: string;
+  meta?: Record<string, any>;
 }
 
 export default function App() {

--- a/src/components/KeywordAnalysis.tsx
+++ b/src/components/KeywordAnalysis.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import '../styles/KeywordAnalysis.css';
+import { AddToCartButton } from './AddToCartButton';
+import type { InsightItem } from '../App';
 
 interface KeywordData {
   rank: number;
@@ -11,7 +13,13 @@ interface KeywordData {
   category: string;
 }
 
-export function KeywordAnalysis() {
+interface KeywordAnalysisProps {
+  addToCart: (item: Omit<InsightItem, 'id' | 'timestamp'>) => void;
+  removeByUniqueKey: (uniqueKey: string) => void;
+  isInCart: (uniqueKey: string) => boolean;
+}
+
+export function KeywordAnalysis({ addToCart, removeByUniqueKey, isInCart }: KeywordAnalysisProps) {
   const [searchTerm, setSearchTerm] = useState('');
   const [selectedCategory, setSelectedCategory] = useState('전체 카테고리');
   const [sortBy, setSortBy] = useState('전체 카테고리');
@@ -62,7 +70,20 @@ export function KeywordAnalysis() {
       <main className="keyword-analysis__main">
         {/* 카테고리별 키워드 분포 차트 */}
         <section className="chart-section">
-          <h2 className="chart-title">카테고리별 키워드 분포</h2>
+          <div className="chart-section__header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <h2 className="chart-title">카테고리별 키워드 분포</h2>
+            <AddToCartButton
+              onAdd={() => addToCart({
+                type: 'chart',
+                title: '카테고리별 키워드 분포',
+                data: categoryData,
+                page: 'keywords',
+                uniqueKey: 'keyword-category-distribution',
+              })}
+              onRemove={() => removeByUniqueKey('keyword-category-distribution')}
+              isInCart={isInCart('keyword-category-distribution')}
+            />
+          </div>
           <div className="bar-chart">
             <div className="chart-bars">
               {/* 가로선과 수치 */}
@@ -94,8 +115,19 @@ export function KeywordAnalysis() {
 
         {/* 키워드 테이블 섹션 */}
         <section className="keyword-section">
-          <div className="keyword-header">
+          <div className="keyword-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
             <h2 className="keyword-title">키워드 순위</h2>
+            <AddToCartButton
+              onAdd={() => addToCart({
+                type: 'table',
+                title: '키워드 순위',
+                data: allKeywords,
+                page: 'keywords',
+                uniqueKey: 'keyword-rankings-table',
+              })}
+              onRemove={() => removeByUniqueKey('keyword-rankings-table')}
+              isInCart={isInCart('keyword-rankings-table')}
+            />
           </div>
 
           <div className="keyword-filters">

--- a/src/components/ReviewAnalysis.tsx
+++ b/src/components/ReviewAnalysis.tsx
@@ -146,6 +146,8 @@ export function ReviewAnalysis({
     loadReviewAnalysis();
   }, [selectedProduct]);
 
+  const selectedProductName = products.find(p => p.productId === selectedProduct)?.name ?? "";
+
   return (
     <div className="review-analysis">
       <main className="review-analysis__main">
@@ -153,21 +155,6 @@ export function ReviewAnalysis({
         <section className="product-selection">
           <div className="product-selection__header">
             <h2 className="product-selection__title">분석할 제품 선택</h2>
-            <div className="product-selection__actions">
-              <AddToCartButton
-                onAdd={() =>
-                  addToCart({
-                    type: "product-selection",
-                    title: "분석할 제품 선택",
-                    data: products,
-                    page: "review",
-                    uniqueKey: "review-product-selection",
-                  })
-                }
-                onRemove={() => removeByUniqueKey("review-product-selection")}
-                isInCart={isInCart("review-product-selection")}
-              />
-            </div>
           </div>
 
           <div className="product-selection__search">
@@ -230,19 +217,22 @@ export function ReviewAnalysis({
               <span className="highlight">고객들이 말합니다</span>
               <span className="count">{reviewAnalysis ? `전체 ${reviewAnalysis.reputation.review_count.toLocaleString()}개 리뷰 분석` : "전체 -개 리뷰"}</span>
             </h3>
-            <AddToCartButton
-              onAdd={() =>
-                  addToCart({
-                    type: "feedback-summary",
-                    title: "고객들이 말합니다 (리뷰 요약)",
-                    data: reviewAnalysis ? { count: reviewAnalysis.reputation.review_count, rating: reviewAnalysis.reputation.rating } : null,
-                    page: "review",
-                    uniqueKey: "review-customer-feedback",
-                  })
-              }
-              onRemove={() => removeByUniqueKey("review-customer-feedback")}
-              isInCart={isInCart("review-customer-feedback")}
-            />
+            {selectedProduct && (
+              <AddToCartButton
+                onAdd={() =>
+                    addToCart({
+                      type: "stat",
+                      title: `${selectedProductName} 고객 리뷰 요약`,
+                      data: reviewAnalysis ? { count: reviewAnalysis.reputation.review_count, rating: reviewAnalysis.reputation.rating } : null,
+                      page: "review-analysis",
+                      uniqueKey: `review-customer-feedback-${selectedProduct}`,
+                      meta: { productId: selectedProduct },
+                    })
+                }
+                onRemove={() => removeByUniqueKey(`review-customer-feedback-${selectedProduct}`)}
+                isInCart={isInCart(`review-customer-feedback-${selectedProduct}`)}
+              />
+            )}
           </div>
           <div className="customer-feedback__rating">
             <span className="rating-label">긍정 반응</span>
@@ -267,21 +257,24 @@ export function ReviewAnalysis({
               <div className="card-header">
                 <h3 className="card-title">감정 분석 분포</h3>
                 <div className="card-header__actions">
-                  <AddToCartButton
-                    onAdd={() =>
-                      addToCart({
-                        type: "chart",
-                        title: "감정 분석 분포",
-                        data: reviewAnalysis ? reviewAnalysis.sentiment : null,
-                        page: "review",
-                        uniqueKey: "review-sentiment-distribution",
-                      })
-                    }
-                    onRemove={() =>
-                      removeByUniqueKey("review-sentiment-distribution")
-                    }
-                    isInCart={isInCart("review-sentiment-distribution")}
-                  />
+                  {selectedProduct && (
+                    <AddToCartButton
+                      onAdd={() =>
+                        addToCart({
+                          type: "chart",
+                          title: `${selectedProductName} 감정 분석 분포`,
+                          data: reviewAnalysis ? reviewAnalysis.sentiment : null,
+                          page: "review-analysis",
+                          uniqueKey: `review-sentiment-distribution-${selectedProduct}`,
+                          meta: { productId: selectedProduct },
+                        })
+                      }
+                      onRemove={() =>
+                        removeByUniqueKey(`review-sentiment-distribution-${selectedProduct}`)
+                      }
+                      isInCart={isInCart(`review-sentiment-distribution-${selectedProduct}`)}
+                    />
+                  )}
                 </div>
               </div>
               <div className="sentiment-chart">
@@ -356,19 +349,22 @@ export function ReviewAnalysis({
               <div className="card-header">
                 <h3 className="card-title">평점 지수</h3>
                 <div className="card-header__actions">
-                  <AddToCartButton
-                    onAdd={() =>
-                      addToCart({
-                        type: "stat",
-                        title: "평점 지수",
-                        data: reviewAnalysis ? { score: reviewAnalysis.reputation.score, rating: reviewAnalysis.reputation.rating } : null,
-                        page: "review",
-                        uniqueKey: "review-rating-index",
-                      })
-                    }
-                    onRemove={() => removeByUniqueKey("review-rating-index")}
-                    isInCart={isInCart("review-rating-index")}
-                  />
+                  {selectedProduct && (
+                    <AddToCartButton
+                      onAdd={() =>
+                        addToCart({
+                          type: "stat",
+                          title: `${selectedProductName} 평점 지수`,
+                          data: reviewAnalysis ? { score: reviewAnalysis.reputation.score, rating: reviewAnalysis.reputation.rating } : null,
+                          page: "review-analysis",
+                          uniqueKey: `review-rating-index-${selectedProduct}`,
+                          meta: { productId: selectedProduct },
+                        })
+                      }
+                      onRemove={() => removeByUniqueKey(`review-rating-index-${selectedProduct}`)}
+                      isInCart={isInCart(`review-rating-index-${selectedProduct}`)}
+                    />
+                  )}
                 </div>
               </div>
               <div className="rating-chart">
@@ -416,19 +412,22 @@ export function ReviewAnalysis({
           <div className="rating-distribution">
             <div className="rating-section-header-row">
               <h3 className="section-title">평점 분포</h3>
-              <AddToCartButton
-                onAdd={() =>
-                  addToCart({
-                    type: "chart",
-                    title: "평점 분포",
-                    data: reviewAnalysis ? reviewAnalysis.rating_distribution : null,
-                    page: "review",
-                    uniqueKey: "review-rating-distribution",
-                  })
-                }
-                onRemove={() => removeByUniqueKey("review-rating-distribution")}
-                isInCart={isInCart("review-rating-distribution")}
-              />
+              {selectedProduct && (
+                <AddToCartButton
+                  onAdd={() =>
+                    addToCart({
+                      type: "chart",
+                      title: `${selectedProductName} 평점 분포`,
+                      data: reviewAnalysis ? reviewAnalysis.rating_distribution : null,
+                      page: "review-analysis",
+                      uniqueKey: `review-rating-distribution-${selectedProduct}`,
+                      meta: { productId: selectedProduct },
+                    })
+                  }
+                  onRemove={() => removeByUniqueKey(`review-rating-distribution-${selectedProduct}`)}
+                  isInCart={isInCart(`review-rating-distribution-${selectedProduct}`)}
+                />
+              )}
             </div>
             <div className="rating-bars">
               {ratingDistribution.map((item) => (
@@ -461,19 +460,22 @@ export function ReviewAnalysis({
               <h2 className="ai-insights__title">
                 AI 키워드 분석 및 비즈니스 인사이트
               </h2>
-              <AddToCartButton
-                onAdd={() =>
-                  addToCart({
-                    type: "insight-list",
-                    title: "AI 키워드 분석 및 비즈니스 인사이트",
-                    data: reviewAnalysis ? reviewAnalysis.keyword_insights : null,
-                    page: "review",
-                    uniqueKey: "review-ai-insights",
-                  })
-                }
-                onRemove={() => removeByUniqueKey("review-ai-insights")}
-                isInCart={isInCart("review-ai-insights")}
-              />
+              {selectedProduct && (
+                <AddToCartButton
+                  onAdd={() =>
+                    addToCart({
+                      type: "insight",
+                      title: `${selectedProductName} AI 키워드 인사이트`,
+                      data: reviewAnalysis ? reviewAnalysis.keyword_insights : null,
+                      page: "review-analysis",
+                      uniqueKey: `review-ai-insights-${selectedProduct}`,
+                      meta: { productId: selectedProduct },
+                    })
+                  }
+                  onRemove={() => removeByUniqueKey(`review-ai-insights-${selectedProduct}`)}
+                  isInCart={isInCart(`review-ai-insights-${selectedProduct}`)}
+                />
+              )}
             </div>
 
             <div className="insights-list">


### PR DESCRIPTION
### 📑 이슈 번호

- close #45

<br>

### ✨️ 작업 내용

- **InsightItem 타입에 `meta` 필드 추가** — AI fetchContext에서 productId, range 등 참조용
- **ReviewAnalysis 장바구니 연결 수정** — page/type 값 정규화, 제품별 동적 uniqueKey, 제품 미선택 시 버튼 숨김
- **KeywordAnalysis 장바구니 버튼 추가** — 카테고리별 키워드 분포(chart), 키워드 순위(table) 담기
- **AIInsights에 리뷰/키워드 데이터 연결** — pocketReviewData 블록 추가, 정적 키워드 항목 3개 추가, `"insight"` 타입 지원

<br>

### 📷 스크린샷 (선택)



### 💭 코멘트

- 리뷰 분석 데이터는 제품 선택 시에만 장바구니 버튼이 노출됩니다
- 키워드 분석의 fetchContext는 현재 더미 데이터입니다 (API 연동 시 교체 필요)

<details>
<summary>이 작업을 진행하는데 사용된 프롬프트</summary>

- Pocket → AI 인사이트 모달 연결 구현 계획 작성 및 실행
- ReviewAnalysis addToCart 6곳 수정 (page, type, meta, uniqueKey)
- KeywordAnalysis에 AddToCartButton 추가
- AIInsights에 pocketReviewData 동적 블록 + 정적 키워드 항목 추가
- 리뷰 분석 uniqueKey에 productId 포함하도록 리팩토링
- AI 인사이트에 넘기는 데이터 구성 문서화 (Notion)

</details>